### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osx-tag",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osx-tag",
-      "version": "0.4.10",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osx-tag",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "description": "Manipulate file tags on macOS",
   "main": "build/Release/osx_tag",
   "scripts": {


### PR DESCRIPTION
## Overview
Bump the package version from 0.4.10 to 0.5.0.

A minor version bump (rather than patch) is used because #20 drops support for Node 16/18/20 (`engines.node` raised to `>=22`), which is a breaking change for those runtimes.